### PR TITLE
Fix php short tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 include_once('./lib/QrReader.php');
 

--- a/lib/QrReader.php
+++ b/lib/QrReader.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 include_once ('Reader.php');
 require_once ('BinaryBitmap.php');


### PR DESCRIPTION
I have changed short php tags to normal in some files, because it was main reason of some problems on servers witch not configured to use short php tags. 

Example: https://www.evernote.com/l/Act8Qs3hqJpNf7kNZeN_df-tOzZco1r0mJc