### PR TITLE
Wrong variable assignment bug

### DIFF
--- a/lib/GDLuminanceSource.php
+++ b/lib/GDLuminanceSource.php
@@ -17,7 +17,6 @@ final class GDLuminanceSource extends LuminanceSource
     private $dataHeight;
     private $left;
     private $top;
-    private $gdImage;
 
     public function __construct(
         $gdImage,
@@ -52,8 +51,6 @@ final class GDLuminanceSource extends LuminanceSource
         $this->dataHeight = $height;
         $this->left       = 0;
         $this->top        = 0;
-        $this->$gdImage   = $gdImage;
-
 
 // In order to measure pure decoding speed, we convert the entire image to a greyscale array
 // up front, which is the same as the Y channel of the YUVLuminanceSource in the real app.
@@ -65,8 +62,8 @@ final class GDLuminanceSource extends LuminanceSource
 
         for ($j = 0; $j < $height; $j++) {
             for ($i = 0; $i < $width; $i++) {
-                $argb  = imagecolorat($this->$gdImage, $i, $j);
-                $pixel = imagecolorsforindex($this->$gdImage, $argb);
+                $argb  = imagecolorat($gdImage, $i, $j);
+                $pixel = imagecolorsforindex($gdImage, $argb);
                 $r     = $pixel['red'];
                 $g     = $pixel['green'];
                 $b     = $pixel['blue'];
@@ -97,7 +94,6 @@ final class GDLuminanceSource extends LuminanceSource
 // Calculate luminance cheaply, favoring green.
                     $this->luminances[(int)($offset + $x)] =  (((($r + 2 * $g + $b) / 4)+128)%256) - 128;
                 }
-
 
 
             }


### PR DESCRIPTION
There is wrong assignment with $this->$gdImage = $gdImage; and it worked only because $gdImage is passed as an argument to GDLuminanceSource() function. 

I think the best solution is to remove this variable, because it is redundant.