### PR TITLE
Fix InvalidArgumentException not caught

### DIFF
--- a/lib/Qrcode/Decoder/Version.php
+++ b/lib/Qrcode/Decoder/Version.php
@@ -110,7 +110,7 @@ class Version
         }
         try {
             return self::getVersionForNumber(($dimension - 17) / 4);
-        } catch (InvalidArgumentException $ignored) {
+        } catch (\InvalidArgumentException $ignored) {
             throw FormatException::getFormatInstance();
         }
     }


### PR DESCRIPTION
Missing namespace on InvalidArgumentException will sometimes causes the entire script to crash because of the inability to catch the error