### PR TITLE
fixed phpunit test case reference

### DIFF
--- a/tests/QrReaderTest.php~
+++ b/tests/QrReaderTest.php~
@@ -4,7 +4,7 @@ namespace Khanamiryan\QrCodeTests;
 
 use Zxing\QrReader;
 
-class QrReaderTest extends \PHPUnit\Framework\TestCase
+class QrReaderTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testText1()


### PR DESCRIPTION
phpunit tests are failing because the reference to PHPUnits Framework TestCase has changed.