### PR TITLE
Fix namespace

### DIFF
--- a/lib/Common/AbstractEnum.php
+++ b/lib/Common/AbstractEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zxing\Common\CharacterSetEci\AbstractEnum;
+namespace Zxing\Common;
 
 use \Zxing\NotFoundException;
 use ReflectionClass;


### PR DESCRIPTION
Note that this file seems entirely unused so maybe it should rather simply be deleted, but as it is it can not be autoloaded by Composer.