### PR TITLE
Added missing class QRCodeDecoderMetaData

### DIFF
--- a/lib/Qrcode/Decoder/QRCodeDecoderMetaData.php
+++ b/lib/Qrcode/Decoder/QRCodeDecoderMetaData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zxing\Qrcode\Decoder;
+
+class QRCodeDecoderMetaData
+{
+    /** @var bool */
+    private $mirrored;
+
+    /**
+     * QRCodeDecoderMetaData constructor.
+     * @param bool $mirrored
+     */
+    public function __construct($mirrored)
+    {
+        $this->mirrored = $mirrored;
+    }
+
+    public function isMirrored()
+    {
+        return $this->mirrored;
+    }
+}


### PR DESCRIPTION
Hi.

This is intended to resolve #51.

This commit is the minimal porting of https://github.com/zxing/zxing/blob/master/core/src/main/java/com/google/zxing/qrcode/decoder/QRCodeDecoderMetaData.java to make it work