### PR TITLE
Support PHP 8

### DIFF
--- a/lib/QrReader.php
+++ b/lib/QrReader.php
@@ -62,7 +62,7 @@ final class QrReader
             $height = $im->getImageHeight();
             $source = new IMagickLuminanceSource($im, $width, $height);
         } else {
-            if (!is_resource($im)) {
+            if (!is_resource($im) && !is_object($im)) {
                 throw new \InvalidArgumentException('Invalid image source.');
             }
             $width  = imagesx($im);


### PR DESCRIPTION
See https://github.com/endroid/qr-code/issues/282 and https://github.com/endroid/qr-code/pull/283

Turns out PHP 8 changed `gd` to return objects rather than resources. This should work as a quick fix to not throw an exception in PHP 8.