### PR TITLE
Fix issue where in some cases the bits could be decoded to the neighbouring char

### DIFF
--- a/lib/ChecksumException.php
+++ b/lib/ChecksumException.php
@@ -27,7 +27,7 @@ final class ChecksumException extends ReaderException
 {
 	private static ?\Zxing\ChecksumException $instance = null;
 
-	public static function getChecksumInstance($cause = null): self
+	public static function getChecksumInstance($cause = ""): self
 	{
 		if (self::$isStackTrace) {
 			return new ChecksumException($cause);

--- a/lib/Common/HybridBinarizer.php
+++ b/lib/Common/HybridBinarizer.php
@@ -266,7 +266,7 @@ final class HybridBinarizer extends GlobalHistogramBinarizer
 		for ($y = 0, $offset = $yoffset * $stride + $xoffset; $y < self::$BLOCK_SIZE; $y++, $offset += $stride) {
 			for ($x = 0; $x < self::$BLOCK_SIZE; $x++) {
 				// Comparison needs to be <= so that black == 0 pixels are black even if the threshold is 0.
-				if (($luminances[(int)round($offset + $x)] & 0xFF) <= $threshold) {
+				if ((((int)$luminances[(int)round($offset + $x)]) & 0xFF) <= $threshold) {
 					$matrix->set($xoffset + $x, $yoffset + $y);
 				}
 			}

--- a/lib/Qrcode/Decoder/DecodedBitStreamParser.php
+++ b/lib/Qrcode/Decoder/DecodedBitStreamParser.php
@@ -208,8 +208,8 @@ final class DecodedBitStreamParser
 			if ($threeDigitsBits >= 1000) {
 				throw new FormatException("Too many three digit bits");
 			}
-			$result .= (self::toAlphaNumericChar($threeDigitsBits / 100));
-			$result .= (self::toAlphaNumericChar(((int)round($threeDigitsBits / 10)) % 10));
+			$result .= (self::toAlphaNumericChar(intdiv($threeDigitsBits, 100)));
+			$result .= (self::toAlphaNumericChar(intdiv($threeDigitsBits, 10) % 10));
 			$result .= (self::toAlphaNumericChar($threeDigitsBits % 10));
 			$count -= 3;
 		}
@@ -222,7 +222,7 @@ final class DecodedBitStreamParser
 			if ($twoDigitsBits >= 100) {
 				throw new FormatException("Too many bits: $twoDigitsBits expected < 100");
 			}
-			$result .= (self::toAlphaNumericChar($twoDigitsBits / 10));
+			$result .= (self::toAlphaNumericChar(intdiv($twoDigitsBits, 10)));
 			$result .= (self::toAlphaNumericChar($twoDigitsBits % 10));
 		} elseif ($count == 1) {
 			// One digit left over to read
@@ -263,7 +263,7 @@ final class DecodedBitStreamParser
 				throw new FormatException("Not enough bits available to read two expected characters");
 			}
 			$nextTwoCharsBits = $bits->readBits(11);
-			$result .= (self::toAlphaNumericChar($nextTwoCharsBits / 45));
+			$result .= (self::toAlphaNumericChar(intdiv($nextTwoCharsBits, 45)));
 			$result .= (self::toAlphaNumericChar($nextTwoCharsBits % 45));
 			$count -= 2;
 		}


### PR DESCRIPTION
As it happens, my change to fix the issues with PHP types, apparently introduced an issue where in some boundary cases the bits were not decoded correctly anymore. 

This PR fixes that at least for all the examples I encountered.