### PR TITLE
When no encoding is detected, default to UTF-8

### DIFF
--- a/lib/Qrcode/Decoder/DecodedBitStreamParser.php
+++ b/lib/Qrcode/Decoder/DecodedBitStreamParser.php
@@ -325,6 +325,8 @@ final class DecodedBitStreamParser
 		} else {
 			$encoding = $currentCharacterSetECI->name();
 		}
+		// in case of no encoding found, default to UTF-8
+		if (empty($encoding)) { $encoding = 'UTF-8'; }
 		$result .= mb_convert_encoding($text, $encoding); //(new String(readBytes, encoding));
 		// $result .= $text; //(new String(readBytes, encoding));
 


### PR DESCRIPTION
I had several QR Code that would end up with empty $encoding, so default to UTF-8 which is what we can expect.